### PR TITLE
fix(admin): reliable product creation with local image fallback + comma decimal parsing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,7 @@ yarn-error.log*
 # Env (segredos)
 .env
 .env.*.local
+
+# Uploaded images
+public/uploads/*
+!public/uploads/.gitkeep

--- a/public/index.html
+++ b/public/index.html
@@ -47,16 +47,24 @@
   const { useState, useEffect, useRef, createContext, useContext } = React;
   const AppContext = createContext();
 
+  async function apiFetch(url, options={}){
+    const res = await fetch(url, options);
+    let data;
+    try{ data = await res.json(); }catch(e){ data = {}; }
+    if(!res.ok) throw new Error(data.error || 'Erro na requisição');
+    return data;
+  }
+
   const api = {
-    loginAdmin: async (password)=> (await fetch('/api/login',{ method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({password}) })).json(),
-    getSettings: async ()=> (await fetch('/api/settings')).json(),
-    getCatalog: async (q)=>{ const params=new URLSearchParams(q||{}).toString(); return (await fetch('/api/catalog'+(params?'?'+params:''))).json() },
-    getAdminProducts: async ()=> (await fetch('/api/admin/products',{ headers: authHeader() })).json(),
-    getProduct: async (id)=> (await fetch('/api/products/'+id,{ headers: authHeader() })).json(),
-    createProduct: async (formData)=> (await fetch('/api/products',{ method:'POST', headers: authHeader(), body: formData })).json(),
-    updateProduct: async (id, formData)=> (await fetch('/api/products/'+id,{ method:'PUT', headers: authHeader(), body: formData })).json(),
-    deleteProduct: async (id)=> (await fetch('/api/products/'+id,{ method:'DELETE', headers: authHeader() })).json(),
-    reorderProducts: async (ids)=> (await fetch('/api/products/reorder',{ method:'POST', headers:{'Content-Type':'application/json', ...authHeader()}, body: JSON.stringify(ids) })).json(),
+    loginAdmin: (password)=> apiFetch('/api/login',{ method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({password}) }),
+    getSettings: ()=> apiFetch('/api/settings'),
+    getCatalog: (q)=>{ const params=new URLSearchParams(q||{}).toString(); return apiFetch('/api/catalog'+(params?'?'+params:'')); },
+    getAdminProducts: ()=> apiFetch('/api/admin/products',{ headers: authHeader() }),
+    getProduct: (id)=> apiFetch('/api/products/'+id,{ headers: authHeader() }),
+    createProduct: (formData)=> apiFetch('/api/products',{ method:'POST', headers: authHeader(), body: formData }),
+    updateProduct: (id, formData)=> apiFetch('/api/products/'+id,{ method:'PUT', headers: authHeader(), body: formData }),
+    deleteProduct: (id)=> apiFetch('/api/products/'+id,{ method:'DELETE', headers: authHeader() }),
+    reorderProducts: (ids)=> apiFetch('/api/products/reorder',{ method:'POST', headers:{'Content-Type':'application/json', ...authHeader()}, body: JSON.stringify(ids) }),
   };
 
   function authHeader(){ const t=localStorage.getItem('token'); return t? { Authorization: 'Bearer '+t } : {}; }
@@ -198,7 +206,7 @@
       try{
         const urls = catalog.products.map(p=>p.imageUrl).filter(Boolean);
         if (navigator.serviceWorker?.controller){
-          navigator.serviceWorker.controller.postMessage({ type:'CACHE_URLS', urls:[ '/api/catalog', ...urls ] });
+          navigator.serviceWorker.controller.postMessage({ type:'CACHE_URLS', urls });
           alert('Conteúdo enviado para cache offline.');
         } else {
           alert('Service Worker não ativo ainda. Recarregue a página após alguns segundos.');
@@ -212,22 +220,22 @@
           <h2 className="text-3xl font-bold mb-2 text-white" style={{textShadow:'1px 1px 3px rgba(0,0,0,0.5)'}}>Certificações</h2>
           <p className="max-w-2xl mx-auto mb-8 text-white" style={{textShadow:'1px 1px 3px rgba(0,0,0,0.4)'}}>Seguimos recomendações rigorosas e controle de qualidade.</p>
           <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
-            {[
-              {src:'https://group-ism.com/br/wp-content/uploads/2023/07/ism-9001.png', title:'ISO 9001', desc:'Gestão da qualidade e melhoria contínua.'},
-              {src:'https://group-ism.com/br/wp-content/uploads/2023/07/ism-14001.png', title:'ISO 14001', desc:'Gestão ambiental e proteção do meio ambiente.'},
-              {src:'https://group-ism.com/br/wp-content/uploads/2023/07/ism-45001-ES.png', title:'ISO 45001', desc:'Segurança e saúde ocupacional no trabalho.'},
-            ].map((it,idx)=>(
-              <div key={idx} className="text-white">
-                <div className="iso-round shadow-lg"><img src={it.src} alt={it.title} /></div>
-                <h3 className="font-bold text-lg">{it.title}</h3>
-                <p className="text-sm opacity-90">{it.desc}</p>
-              </div>
-            ))}
+              {[ 
+                {src:'https://group-ism.com/br/wp-content/uploads/2023/07/ism-9001.png', title:'ISO 9001', desc:'Gestão da qualidade e melhoria contínua.'},
+                {src:'https://group-ism.com/br/wp-content/uploads/2023/07/ism-14001.png', title:'ISO 14001', desc:'Gestão ambiental e proteção do meio ambiente.'},
+                {src:'https://group-ism.com/br/wp-content/uploads/2023/07/ism-45001-ES.png', title:'ISO 45001', desc:'Segurança e saúde ocupacional no trabalho.'},
+              ].map((it,idx)=>(
+                <div key={idx} className="text-white">
+                  <div className="iso-round shadow-lg"><img crossOrigin="anonymous" src={it.src} alt={it.title} /></div>
+                  <h3 className="font-bold text-lg">{it.title}</h3>
+                  <p className="text-sm opacity-90">{it.desc}</p>
+                </div>
+              ))}
           </div>
         </div>
 
         <div className="banner mb-6 rounded-2xl overflow-hidden shadow-lg">
-          <img src="https://i.ibb.co/yFDqWmt0/IMG-0854.jpg" alt="Banner Topo" onError={(e)=>{e.target.src='https://placehold.co/1200x340/0f8a3a/ffffff?text=Banner'}}/>
+          <img crossOrigin="anonymous" src="https://i.ibb.co/yFDqWmt0/IMG-0854.jpg" alt="Banner Topo" onError={(e)=>{e.target.src='https://placehold.co/1200x340/0f8a3a/ffffff?text=Banner'}}/>
         </div>
 
         <div className="panel p-6 mb-8">
@@ -266,7 +274,7 @@
                 <>
                   {group.category === 'Bebidas alcoólicas' && (
                     <div className="mb-6 rounded-2xl overflow-hidden shadow-lg">
-                      <img src="https://i.ibb.co/Vp9Pshb4/IMG-0863.jpg" alt="Novas Cervejas" className="w-full h-auto object-contain"/>
+                      <img crossOrigin="anonymous" src="https://i.ibb.co/Vp9Pshb4/IMG-0863.jpg" alt="Novas Cervejas" className="w-full h-auto object-contain"/>
                     </div>
                   )}
                   <h2 className="text-3xl font-bold text-white mb-4" style={{textShadow:'1px 1px 3px rgba(0,0,0,0.5)'}}>{group.category}</h2>
@@ -319,7 +327,17 @@
     const [loading,setLoading]=useState(true);
     const ref = useRef(null);
 
-    const load = async ()=>{ setLoading(true); const data = await api.getAdminProducts(); setProducts(Array.isArray(data)? data : []); setLoading(false); };
+    const load = async ()=>{ 
+      setLoading(true); 
+      try{
+        const data = await api.getAdminProducts(); 
+        setProducts(Array.isArray(data)? data : []);
+      }catch(e){
+        alert('Erro ao carregar produtos');
+        setProducts([]);
+      }
+      setLoading(false); 
+    };
     useEffect(()=>{ load() },[]);
 
     useEffect(()=>{
@@ -362,7 +380,7 @@
                   <td className="p-3 text-center handle text-gray-400 cursor-move">☰</td>
                   <td className="p-3 font-semibold text-gray-800">
                     <div className="flex items-center gap-3">
-                      <img src={p.imageUrl||'/img/placeholder.png'} className="w-12 h-12 object-contain rounded bg-gray-100 p-1"/>
+                      <img crossOrigin="anonymous" src={p.imageUrl||'/img/placeholder.png'} className="w-12 h-12 object-contain rounded bg-gray-100 p-1"/>
                       <div>{p.name}<div className="text-xs text-gray-500 font-normal">Códigos: {p.codes || '-'}</div></div>
                     </div>
                   </td>
@@ -383,7 +401,7 @@
         <div className="md:hidden space-y-4">
           {loading ? <div className="text-center text-white">Carregando...</div> : products.map(p => (
             <div key={p._id} className="panel p-4 flex gap-4 items-center">
-              <img src={p.imageUrl||'/img/placeholder.png'} className="w-16 h-16 object-contain rounded bg-gray-100 p-1"/>
+              <img crossOrigin="anonymous" src={p.imageUrl||'/img/placeholder.png'} className="w-16 h-16 object-contain rounded bg-gray-100 p-1"/>
               <div className="flex-grow">
                 <h3 className="font-bold text-gray-800">{p.name}</h3>
                 <p className="text-sm text-gray-500">{p.category}</p>
@@ -405,6 +423,8 @@
     const id = route.params?.id || new URLSearchParams(location.search).get('id');
     const [product,setProduct]=useState(null);
     const [loading,setLoading]=useState(true);
+    const [saving,setSaving]=useState(false);
+    const [error,setError]=useState('');
     const [imagePreview,setImagePreview]=useState(null);
     const fileRef = useRef(null);
     const [categories,setCategories]=useState([]);
@@ -428,8 +448,14 @@
       const fd = new FormData();
       Object.entries(product).forEach(([k,v])=>{ if(['priceUV','priceUP','priceFV','priceFP'].includes(k) && (v===undefined||v===null||v==='')) return; fd.append(k, v); });
       if (fileRef.current?.files?.[0]) fd.append('image', fileRef.current.files[0]);
-      if (id) await api.updateProduct(id, fd); else await api.createProduct(fd);
-      navigate('admin/products');
+      setSaving(true); setError('');
+      try{
+        await (id ? api.updateProduct(id, fd) : api.createProduct(fd));
+        navigate('admin/products');
+      }catch(e){
+        setError(e.message || 'Erro ao salvar produto');
+      }
+      setSaving(false);
     };
 
     if (loading) return <div className="text-center text-white text-2xl font-bold pt-20">Carregando...</div>;
@@ -439,6 +465,7 @@
       <div className="container mx-auto p-4 sm:p-6 lg:p-8">
         <h1 className="text-3xl font-bold text-white mb-6" style={{textShadow:'1px 1px 3px rgba(0,0,0,0.5)'}}>{id? 'Editar Produto':'Adicionar Produto'}</h1>
         <div className="panel p-8 text-gray-800">
+          {error && <div className="mb-4 text-red-600">Erro: {error}</div>}
           <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
             <div className="md:col-span-2 space-y-6">
               <div className="grid grid-cols-1 sm:grid-cols-2 gap-6">
@@ -467,7 +494,7 @@
             <div className="space-y-2">
               <label className="block font-semibold mb-1">Imagem do Produto</label>
               <div className="w-full h-52 bg-gray-100 rounded-lg flex items-center justify-center border-2 border-dashed">
-                {imagePreview? <img src={imagePreview} className="h-full w-full object-contain rounded-lg"/> : <span className="text-gray-500">Pré-visualização</span>}
+                  {imagePreview? <img crossOrigin="anonymous" src={imagePreview} className="h-full w-full object-contain rounded-lg"/> : <span className="text-gray-500">Pré-visualização</span>}
               </div>
               <input ref={fileRef} type="file" accept="image/*" onChange={onImage} className="hidden"/>
               <button onClick={()=>fileRef.current.click()} className="w-full bg-gray-200 text-gray-800 font-semibold py-2 rounded-lg hover:bg-gray-300">Adicionar Imagem</button>
@@ -476,8 +503,8 @@
           <div className="mt-6 flex items-center justify-between">
             <label className="flex items-center gap-2"><input type="checkbox" name="active" checked={!!product.active} onChange={(e)=>setProduct(p=>({...p, active:e.target.checked}))}/> Ativo</label>
             <div className="flex gap-2">
-              <button onClick={()=>navigate('admin/products')} className="bg-gray-200 text-gray-800 font-semibold px-6 py-2 rounded-lg">Cancelar</button>
-              <button onClick={save} className="bg-green-600 text-white font-semibold px-6 py-2 rounded-lg">Salvar</button>
+              <button onClick={()=>navigate('admin/products')} className="bg-gray-200 text-gray-800 font-semibold px-6 py-2 rounded-lg" disabled={saving}>Cancelar</button>
+              <button onClick={save} disabled={saving} className="bg-green-600 text-white font-semibold px-6 py-2 rounded-lg disabled:bg-gray-400">{saving?'Salvando...':'Salvar'}</button>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- normalize numeric and boolean payloads, validate required fields, and fall back to local `/public/uploads` when Cloudinary is missing or fails
- surface API errors and loading states in the admin UI with a shared fetch helper
- avoid caching `/api/*` in the service worker and immediately activate new SW versions

## Testing
- `npm test` *(fails: Missing script "test")*
- `node - <<'NODE' ...` (MongoMemoryServer: created product with and without image; catalog list returned 2 items)

### curl examples
```
# login
curl -s -X POST http://localhost:10001/api/login \
  -H "Content-Type: application/json" \
  -d '{"password":"1234"}'

# create without image
curl -s -X POST http://localhost:10001/api/products \
  -H "Authorization: Bearer <TOKEN>" \
  -H "Content-Type: application/json" \
  -d '{"name":"Café","category":"Bebidas","priceUV":"12,50","active":"true"}'

# create with image (fallback local)
curl -s -X POST http://localhost:10001/api/products \
  -H "Authorization: Bearer <TOKEN>" \
  -F "name=Café com foto" \
  -F "category=Bebidas" \
  -F "priceUV=9,90" \
  -F "active=true" \
  -F "image=@./public/img/placeholder.png"
```

------
https://chatgpt.com/codex/tasks/task_e_68b8e9b4d76083339014dc15f4fcf386